### PR TITLE
OPS-6491 Fix default values for `output_options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,18 +140,18 @@ Type:
 
 ```hcl
 object({
-    batch_prefix     = optional(string, "")
-    batch_suffix     = optional(string, "")
+    batch_prefix     = optional(string)
+    batch_suffix     = optional(string)
     cve_2021_44228   = optional(bool, false)
-    field_delimiter  = optional(string, "")
+    field_delimiter  = optional(string)
     field_names      = optional(list(string))
     output_type      = optional(string, "ndjson")
-    record_delimiter = optional(string, "")
-    record_prefix    = optional(string, "")
-    record_suffix    = optional(string, "")
-    record_template  = optional(string, "")
+    record_delimiter = optional(string)
+    record_prefix    = optional(string)
+    record_suffix    = optional(string)
+    record_template  = optional(string)
     # Floating number to specify sampling rate. Sampling is applied on top of filtering, and regardless of the current sample_interval of the data
-    sample_rate      = optional(number, 1)
+    sample_rate      = optional(number)
     timestamp_format = optional(string, "rfc3339")
   })
 ```

--- a/examples/challenge/main.tf
+++ b/examples/challenge/main.tf
@@ -23,6 +23,7 @@ module "example" {
   s3_bucket_name = "your-s3-bucket-for-logs"
   s3_path        = "example.com/{DATE}"
   output_options = {
+    cve_2021_44228 = true
     field_names = [
       "RayID",
       "ClientIP",
@@ -34,6 +35,7 @@ module "example" {
       "EdgeStartTimestamp",
       "EdgeEndTimestamp"
     ]
+    sample_rate = 1
   }
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -3,4 +3,6 @@ locals {
 
   aws_region       = var.ownership_challenge == null ? data.aws_region.this[0].region : var.s3_region
   destination_conf = "s3://${var.s3_bucket_name}/${var.s3_path}?region=${local.aws_region}"
+
+  output_options = { for key, option in var.output_options : key => option if option != null }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,6 @@
 output "job" {
   description = "A created logpush job"
-  value       = { for k, v in cloudflare_logpush_job.this : k => v if k != "ownership_challenge" }
+  value = { for k, v in cloudflare_logpush_job.this :
+    k => v if !contains(["ownership_challenge", "last_complete"], k)
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -71,18 +71,18 @@ variable "name" {
 variable "output_options" {
   description = "Configuration string for requested fields and timestamp formats"
   type = object({
-    batch_prefix     = optional(string, "")
-    batch_suffix     = optional(string, "")
+    batch_prefix     = optional(string)
+    batch_suffix     = optional(string)
     cve_2021_44228   = optional(bool, false)
-    field_delimiter  = optional(string, "")
+    field_delimiter  = optional(string)
     field_names      = optional(list(string))
     output_type      = optional(string, "ndjson")
-    record_delimiter = optional(string, "")
-    record_prefix    = optional(string, "")
-    record_suffix    = optional(string, "")
-    record_template  = optional(string, "")
+    record_delimiter = optional(string)
+    record_prefix    = optional(string)
+    record_suffix    = optional(string)
+    record_template  = optional(string)
     # Floating number to specify sampling rate. Sampling is applied on top of filtering, and regardless of the current sample_interval of the data
-    sample_rate      = optional(number, 1)
+    sample_rate      = optional(number)
     timestamp_format = optional(string, "rfc3339")
   })
   default = {}


### PR DESCRIPTION
- Only set values should be passed to `logpush_job`, otherwise there are situation when constant dirft occurs
- Default value for `record_template` causing logpush job to send empty log files
- `last_complete` causing constant drift in outputs - removed