### PR TITLE
OPS-0 Fix outputs after migrating to v5 schema

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,6 +14,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ FL_IGNORE_PATHS = .git/,.github/,.terraform/,.idea/
 # Container versions
 # -------------------------------------------------------------------------------------------------
 TF_VERSION      = 1.8.5
-TFDOCS_VERSION  = 0.16.0-0.34
+TFDOCS_VERSION  = 0.20.0-0.37
 FL_VERSION      = latest-0.8
 JL_VERSION      = 1.6.0-0.14
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Template for Terraform modules
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.8 |
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | ~> 5.8 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.51 |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | ~> 5.21 |
 
 <!-- TFDOCS_PROVIDER_END -->
 
@@ -29,8 +29,8 @@ Template for Terraform modules
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.8 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.8 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.51 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.21 |
 
 <!-- TFDOCS_REQUIREMENTS_END -->
 

--- a/examples/challenge/README.md
+++ b/examples/challenge/README.md
@@ -8,8 +8,8 @@ Terraform should have provider configured with access to S3-bucket to fetch cont
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.8 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.8 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.51 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.21 |
 
 ## Providers
 

--- a/examples/challenge/versions.tf
+++ b/examples/challenge/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.8"
+      version = "~> 6.51"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.8"
+      version = "~> 5.21"
     }
   }
   required_version = "~> 1.3"

--- a/examples/no-challenge/README.md
+++ b/examples/no-challenge/README.md
@@ -8,7 +8,7 @@ You have to create your ownership challenge on your own and submit a content of 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.8 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.21 |
 
 ## Providers
 

--- a/examples/no-challenge/versions.tf
+++ b/examples/no-challenge/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.8"
+      version = "~> 5.21"
     }
   }
   required_version = "~> 1.3"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "job" {
   description = "A created logpush job"
   value = { for k, v in cloudflare_logpush_job.this :
-    k => v if !contains(["ownership_challenge", "last_complete"], k)
+    k => v if !contains(["destination_conf", "last_complete", "ownership_challenge"], k)
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.8"
+      version = "~> 6.51"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.8"
+      version = "~> 5.21"
     }
   }
   required_version = "~> 1.3"


### PR DESCRIPTION
- after changes introduced in `v5.19` with migrating schema to `v5` (https://github.com/cloudflare/terraform-provider-cloudflare/commit/3cc2f6ec126141ee9e37292f7980109e32077dcf) - `destination_conf` became sensitive and we have to excluded it from output